### PR TITLE
Add support for openssh key format (default format of ssh-keygen)

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,7 +1,7 @@
 assembly-versioning-scheme: MajorMinorPatchTag
 mode: ContinuousDeployment
 tag-prefix: v20|20|v
-next-version: 0.28.2
+next-version: 0.28.3
 continuous-delivery-fallback-tag: ''
 commit-message-incrementing: Disabled
 branches:


### PR DESCRIPTION
The support is only available on the libssh2 master branch
If we don't enable this, only keys generated with the -m "PEM" switch would be supported