### PR TITLE
Add support for net5.0-windows

### DIFF
--- a/nuget.package/build/net5.0-windows/LibGit2Sharp.NativeBinaries.UiPath.props
+++ b/nuget.package/build/net5.0-windows/LibGit2Sharp.NativeBinaries.UiPath.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\net46\LibGit2Sharp.NativeBinaries.UiPath.props" />
+</Project>

--- a/nuget.package/buildMultiTargeting/net5.0-windows/LibGit2Sharp.NativeBinaries.UiPath.props
+++ b/nuget.package/buildMultiTargeting/net5.0-windows/LibGit2Sharp.NativeBinaries.UiPath.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\..\build\net46\LibGit2Sharp.NativeBinaries.UiPath.props" />
+</Project>


### PR DESCRIPTION
Use the same build action as the net46 target as this package only contains native dlls.
I used net5.0-windows, because the native dlls are actually windows only, so a more generic target like net5.0 would not be correct.