### PR TITLE
Revert "Add support for net5.0-windows"

### DIFF
--- a/nuget.package/build/net5.0-windows/LibGit2Sharp.NativeBinaries.UiPath.props
+++ b/nuget.package/build/net5.0-windows/LibGit2Sharp.NativeBinaries.UiPath.props
@@ -1,3 +1,0 @@
-<Project>
-  <Import Project="..\net46\LibGit2Sharp.NativeBinaries.UiPath.props" />
-</Project>

--- a/nuget.package/buildMultiTargeting/net5.0-windows/LibGit2Sharp.NativeBinaries.UiPath.props
+++ b/nuget.package/buildMultiTargeting/net5.0-windows/LibGit2Sharp.NativeBinaries.UiPath.props
@@ -1,3 +1,0 @@
-<Project>
-  <Import Project="..\..\build\net46\LibGit2Sharp.NativeBinaries.UiPath.props" />
-</Project>


### PR DESCRIPTION
This reverts commit fb04d76d6d8271df137f92dc73de657e2f8486ed.
For net5 the binaries are automatically copied in the output runtimes folder