### PR TITLE
UI-43552. Fix version generation

### DIFF
--- a/Get-Version.ps1
+++ b/Get-Version.ps1
@@ -3,7 +3,7 @@ function Get-Version
    	    $packageVersion = "4.0.0"
 	    Write-Host "Resolving GitVersion.exe..."
 		Register-PackageSource -Name "officialNugetV2" -Location "http://www.nuget.org/api/v2/" -ProviderName "NuGet" -ErrorAction SilentlyContinue
-		Install-Package GitVersion.CommandLine -MinimumVersion $packageVersion -Source "officialNugetV2" -Force -Scope CurrentUser 
+		Install-Package GitVersion.CommandLine -RequiredVersion $packageVersion -Source "officialNugetV2" -Force -Scope CurrentUser
 		UnRegister-PackageSource -Name "officialNugetV2"
 		$gitVersionDir = (Get-Item (Get-Package GitVersion.CommandLine).Source).DirectoryName + "\tools" 
 		$Env:Path += ";" + $gitVersionDir


### PR DESCRIPTION
Version generation based on commit history/branches is broken because the existing scripts are not compatible anymore with newer versions of `gitversion`. Given this, I have changed our build scripts to retrieve an older version of `gitversion` - `4.0.0`. 
This seems to work fine.