### PR TITLE
Add build configuration for using schannel STUD-6_5739

### DIFF
--- a/build.libgit2.ps1
+++ b/build.libgit2.ps1
@@ -24,12 +24,11 @@ $libssh2Directory = ([System.Uri](Join-Path $projectDirectory "libssh2")).Absolu
 $x86Directory = Join-Path $projectDirectory "nuget.package\runtimes\win-x86\native"
 $x64Directory = Join-Path $projectDirectory "nuget.package\runtimes\win-x64\native"
 $hashFile = Join-Path $projectDirectory "nuget.package\libgit2\libgit2_hash.txt"
-$sha = Get-Content $hashFile 
 
 if (![string]::IsNullOrEmpty($libgit2Name)) {
     $binaryFilename = $libgit2Name
 } else {
-    $binaryFilename = "git2-" + $sha.Substring(0,7)
+    $binaryFilename = "libgit2"
 }
 
 $build_clar = 'OFF'
@@ -109,19 +108,29 @@ function Build-LibSsh($generator, $platform, $buildDir) {
 	Run-Command -Quiet -Fatal { & $cmake --build . --config $configuration }
 }
 
-function Build-LibGit($generator, $platform, $nugetDir) {
-	Write-Output "Building $platform..."
+function Build-LibGit($generator, $platform, $nugetDir, $useSchannel, $buildPlatform) {
 	$libsshBuildDir = "$libssh2Directory/build/$platform"
 	$libsshBinDir = "$libsshBuildDir/src/$configuration"
 	$libopensslBinDir = "$libopensslDirectory/$platform/bin"
-	Build-LibSsh $generator $platform $libsshBuildDir
-		
+    if ($buildPlatform) {
+        Write-Output "Building $platform..."
+        Build-LibSsh $generator $platform $libsshBuildDir
+    }
+
 	$buildDir = [IO.Path]::Combine( $libgit2Directory, "build", $platform)
 	Run-Command -Quiet { & remove-item $buildDir -recurse -force }
 	[IO.Directory]::CreateDirectory($buildDir)
     cd $buildDir
-	Write-Output "CONFIGURE LIBGIT..."
-	Run-Command -Quiet -Fatal { & $cmake -G $generator -A $platform -D ENABLE_TRACE=ON -D "BUILD_CLAR=$build_clar" -D "LIBGIT2_FILENAME=$binaryFilename" -D "USE_SSH=False" -D "LIBSSH2_INCLUDE_DIRS=$libssh2Directory/include" -D "LIBSSH2_LIBRARIES=$libsshBinDir/libssh2.lib" -D "LIBSSH2_FOUND=TRUE" -D "OPENSSL_ROOT_DIR=$libopensslDirectory/$platform" $libgit2Directory }
+    $variantFilename = $binaryFileName
+    if ($useSchannel) {
+        $variantFilename = -join ($binaryFileName, "_schannel")
+    }
+	Write-Output "CONFIGURE LIBGIT... Schannel: $useSchannel"
+    $httpsConfig = ""
+    if ($useSchannel) {
+        $httpsConfig = "-D `"USE_HTTPS=Schannel`""
+    }
+	Run-Command -Fatal { & $cmake -G $generator -A $platform -D ENABLE_TRACE=ON -D "BUILD_CLAR=$build_clar" -D "BUILD_TESTS=OFF" -D "BUILD_CLI=OFF" $httpsConfig -D "LIBGIT2_FILENAME=$variantFilename" -D "USE_SSH=False" -D "LIBSSH2_INCLUDE_DIRS=$libssh2Directory/include" -D "LIBSSH2_LIBRARIES=$libsshBinDir/libssh2.lib" -D "LIBSSH2_FOUND=TRUE" -D "OPENSSL_ROOT_DIR=$libopensslDirectory/$platform" $libgit2Directory }
 	Write-Output "BUILD LIBGIT..."
 	Run-Command -Quiet -Fatal { & $cmake --build . --config $configuration }
     if ($test.IsPresent) { Run-Command -Quiet -Fatal { & $ctest -V . } }
@@ -158,7 +167,8 @@ try {
     $cmake = Find-CMake
     $ctest = Join-Path (Split-Path -Parent $cmake) "ctest.exe"
 	
-	Build-LibGit "Visual Studio $vs" "x64" $x64Directory
+	Build-LibGit "Visual Studio $vs" "x64" $x64Directory $false $true
+	Build-LibGit "Visual Studio $vs" "x64" $x64Directory $true $false
 
     Write-Output "Done!"
 }

--- a/build.libgit2.ps1
+++ b/build.libgit2.ps1
@@ -158,7 +158,6 @@ try {
     $cmake = Find-CMake
     $ctest = Join-Path (Split-Path -Parent $cmake) "ctest.exe"
 	
-    Build-LibGit "Visual Studio $vs" "Win32" $x86Directory
 	Build-LibGit "Visual Studio $vs" "x64" $x64Directory
 
     Write-Output "Done!"

--- a/nuget.package/build/LibGit2Sharp.NativeBinaries.UiPath.props
+++ b/nuget.package/build/LibGit2Sharp.NativeBinaries.UiPath.props
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <libgit2_propsfile>$(MSBuildThisFileFullPath)</libgit2_propsfile>
-    <libgit2_hash>572e4d8c1f1d42feac1c770f0cddf6fda6c4eca0</libgit2_hash>
-    <libgit2_filename>git2-572e4d8</libgit2_filename>
+    <libgit2_filename>libgit2</libgit2_filename>
   </PropertyGroup>
 </Project>

--- a/nuget.package/build/net46/LibGit2Sharp.NativeBinaries.UiPath.props
+++ b/nuget.package/build/net46/LibGit2Sharp.NativeBinaries.UiPath.props
@@ -1,17 +1,16 @@
 ﻿<Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <libgit2_propsfile>$(MSBuildThisFileFullPath)</libgit2_propsfile>
-    <libgit2_hash>572e4d8c1f1d42feac1c770f0cddf6fda6c4eca0</libgit2_hash>
-    <libgit2_filename>git2-572e4d8</libgit2_filename>
+    <liblibgit2_propsfile>$(MSBuildThisFileFullPath)</liblibgit2_propsfile>
+    <liblibgit2_filename>libgit2</liblibgit2_filename>
   </PropertyGroup>
   <ItemGroup>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\git2-572e4d8.dll')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\git2-572e4d8.dll">
-      <TargetPath>lib\win32\x64\git2-572e4d8.dll</TargetPath>
+    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\libgit2.dll')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\libgit2.dll">
+      <TargetPath>lib\win32\x64\libgit2.dll</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\git2-572e4d8.pdb')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\git2-572e4d8.pdb">
-      <TargetPath>lib\win32\x64\git2-572e4d8.pdb</TargetPath>
+	<ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\libgit2_schannel.dll')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\libgit2_schannel.dll">
+      <TargetPath>lib\win32\x64\libgit2_schannel.dll</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </ContentWithTargetPath>
 	<ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\libssh2.dll')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x64\native\libssh2.dll">
@@ -22,5 +21,4 @@
       <TargetPath>lib\win32\x64\libcrypto-1_1-x64.dll</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </ContentWithTargetPath>
-  </ItemGroup>
 </Project>

--- a/nuget.package/build/net46/LibGit2Sharp.NativeBinaries.UiPath.props
+++ b/nuget.package/build/net46/LibGit2Sharp.NativeBinaries.UiPath.props
@@ -22,53 +22,5 @@
       <TargetPath>lib\win32\x64\libcrypto-1_1-x64.dll</TargetPath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\git2-572e4d8.dll')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\git2-572e4d8.dll">
-      <TargetPath>lib\win32\x86\git2-572e4d8.dll</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\git2-572e4d8.pdb')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\git2-572e4d8.pdb">
-      <TargetPath>lib\win32\x86\git2-572e4d8.pdb</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-	<ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\libssh2.dll')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\libssh2.dll">
-      <TargetPath>lib\win32\x86\libssh2.dll</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-	<ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\libcrypto-1_1.dll')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\win-x86\native\libcrypto-1_1.dll">
-      <TargetPath>lib\win32\x86\libcrypto-1_1.dll</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\osx\native\libgit2-572e4d8.dylib')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\osx\native\libgit2-572e4d8.dylib">
-      <TargetPath>lib\osx\libgit2-572e4d8.dylib</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\linux-x64\native\libgit2-572e4d8.so')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\linux-x64\native\libgit2-572e4d8.so">
-      <TargetPath>lib\linux-x64\libgit2-572e4d8.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\ubuntu.18.04-x64\native\libgit2-572e4d8.so')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\ubuntu.18.04-x64\native\libgit2-572e4d8.so">
-      <TargetPath>lib\ubuntu.18.04-x64\libgit2-572e4d8.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\rhel-x64\native\libgit2-572e4d8.so')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\rhel-x64\native\libgit2-572e4d8.so">
-      <TargetPath>lib\rhel-x64\libgit2-572e4d8.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\fedora-x64\native\libgit2-572e4d8.so')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\fedora-x64\native\libgit2-572e4d8.so">
-      <TargetPath>lib\fedora-x64\libgit2-572e4d8.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\debian.9-x64\native\libgit2-572e4d8.so')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\debian.9-x64\native\libgit2-572e4d8.so">
-      <TargetPath>lib\debian.9-x64\libgit2-572e4d8.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Condition="Exists('$(MSBuildThisFileDirectory)\..\..\runtimes\alpine-x64\native\libgit2-572e4d8.so')" Include="$(MSBuildThisFileDirectory)\..\..\runtimes\alpine-x64\native\libgit2-572e4d8.so">
-      <TargetPath>lib\alpine-x64\libgit2-572e4d8.so</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)\..\..\libgit2\LibGit2Sharp.dll.config">
-      <TargetPath>LibGit2Sharp.dll.config</TargetPath>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </ContentWithTargetPath>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Output package now contains two versions of libgit2:
  - libgit2.dll -> winhttp (default)
  - libgi2_schannel.dll -> windows secure channel (future default)

- remove x86 build
- remove pdbs from build props (not copied to studio bin anymore)

part of https://uipath.atlassian.net/browse/STUD-6_5739
